### PR TITLE
inconsistency with bitwarden versions

### DIFF
--- a/docs/guides/security/self-hosted-password-management-with-bitwarden-rs/index.md
+++ b/docs/guides/security/self-hosted-password-management-with-bitwarden-rs/index.md
@@ -221,7 +221,7 @@ As an additional security precaution, you may elect to disable user registration
 
 1. Start a new bitwarden container, but with the `SIGNUPS_ALLOWED` environment variable set to `false`.
 
-        sudo docker run -d --name bitwarden -v /srv/bitwarden:/data -e WEBSOCKET_ENABLED=true -e SIGNUPS_ALLOWED=false -p 127.0.0.1:8080:80 -p 127.0.0.1:3012:3012 --restart on-failure bitwardenrs/server:1.13.1
+        sudo docker run -d --name bitwarden -v /srv/bitwarden:/data -e WEBSOCKET_ENABLED=true -e SIGNUPS_ALLOWED=false -p 127.0.0.1:8080:80 -p 127.0.0.1:3012:3012 --restart on-failure bitwardenrs/server:latest
 
 1. If you attempt to create a new account after these changes, the following error appears on the account creation page.
 


### PR DESCRIPTION
Early on in the doc it downloads the latest version of bitwardenrs, later on you delete it and then reinstall. The later reinstall had a hardcoded version that is incompatible with the newer version that was previously installed

https://www.linode.com/community/questions/21147/how-do-i-notify-linode-that-a-guide-has-an-error-in-it#answer-75749